### PR TITLE
Fixed bug involving accessing latex templates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/GeneralFunctions.jl
+++ b/src/GeneralFunctions.jl
@@ -87,22 +87,40 @@ function create_main_files(parentPath::String, projectName::String, projectLang:
     if projectLang == "latex" # LaTeX projects are different, so handle them first. (no script vs module)
         mkdir(mainDirPath * "images") # create images directory
 
-        # copy latex file from template
-        templateString = "" # initialize string
-
-        open("./src/templates/latexTemplate") do io 
-            for line in eachline(io) # for each line in template file
-                if line == "\\title{Placeholder}" # if title section, replace with project title
-                    templateString = templateString * "\\title{$projectName}\n"
-                else
-                    templateString = templateString * line * "\n" # append line to string
-                end # if 
-            end # for
-        end # open
-
         # write template to main file
         open(mainDirPath * mainDirName * ".tex", "w") do io 
-            println(io, templateString) # write template to file
+            println(io, "\\documentclass{article}")
+            println(io, "\\usepackage[utf8]{inputenc}")
+            println(io, "\\usepackage{textcomp}")
+            println(io, "\\usepackage{gensymb}")
+            println(io, "\\usepackage{graphicx}")
+            println(io, "\\usepackage{multicol}")
+            println(io, "\\usepackage{amsmath}")
+            println(io, "\\usepackage{amssymb}")
+            println(io, "\\usepackage{physics}")
+            println(io, "\\usepackage{hyperref}")
+            println(io, "\\usepackage{cancel}")
+
+            println(io, "\\graphicspath{ {./images/} }")
+
+            println(io, "\\oddsidemargin=-.3in")
+            println(io, "\\evensidemargin=-.5in")
+            println(io, "\\textwidth=7in")
+            println(io, "\\topmargin=-1in")
+            println(io, "\\textheight=10in")
+
+            println(io, "\\parindent=.2in")
+            println(io, "\\pagestyle{plain}")
+
+            println(io, "\\title{Placeholder}")
+            println(io, "\\author{}")
+            println(io, "\\date{}")
+
+            println(io, "\\begin{document}")
+
+            println(io, "\\maketitle")
+
+            println(io, "\\end{document}")
         end # open
 
     elseif projectLang == "julia"

--- a/src/GeneralFunctions.jl
+++ b/src/GeneralFunctions.jl
@@ -89,6 +89,7 @@ function create_main_files(parentPath::String, projectName::String, projectLang:
 
         # write template to main file
         open(mainDirPath * mainDirName * ".tex", "w") do io 
+            # create basic file with some formatting and useful packages imported
             println(io, "\\documentclass{article}")
             println(io, "\\usepackage[utf8]{inputenc}")
             println(io, "\\usepackage{textcomp}")
@@ -112,16 +113,16 @@ function create_main_files(parentPath::String, projectName::String, projectLang:
             println(io, "\\parindent=.2in")
             println(io, "\\pagestyle{plain}")
             println(io, "\n")
-            println(io, "\\title{Placeholder}")
+            println(io, "\\title{$projectName}") # put in name of project
             println(io, "\\author{}")
-            println(io, "\\date{}")
+            println(io, "\\date{$(string(monthname(today()))) $(year(today()))}") # format project with current month and year
             println(io, "\n")
             println(io, "\\begin{document}")
             println(io, "\n")
             println(io, "\\maketitle")
             println(io, "\n")
             println(io, "\\end{document}")
-            
+
         end # open
 
     elseif projectLang == "julia"

--- a/src/GeneralFunctions.jl
+++ b/src/GeneralFunctions.jl
@@ -100,27 +100,28 @@ function create_main_files(parentPath::String, projectName::String, projectLang:
             println(io, "\\usepackage{physics}")
             println(io, "\\usepackage{hyperref}")
             println(io, "\\usepackage{cancel}")
-
+            println(io, "\n")
             println(io, "\\graphicspath{ {./images/} }")
-
+            println(io, "\n")
             println(io, "\\oddsidemargin=-.3in")
             println(io, "\\evensidemargin=-.5in")
             println(io, "\\textwidth=7in")
             println(io, "\\topmargin=-1in")
             println(io, "\\textheight=10in")
-
+            println(io, "\n")
             println(io, "\\parindent=.2in")
             println(io, "\\pagestyle{plain}")
-
+            println(io, "\n")
             println(io, "\\title{Placeholder}")
             println(io, "\\author{}")
             println(io, "\\date{}")
-
+            println(io, "\n")
             println(io, "\\begin{document}")
-
+            println(io, "\n")
             println(io, "\\maketitle")
-
+            println(io, "\n")
             println(io, "\\end{document}")
+            
         end # open
 
     elseif projectLang == "julia"

--- a/src/LatexProject.jl
+++ b/src/LatexProject.jl
@@ -1,5 +1,7 @@
 module LatexProject 
 
+using Dates
+
 include("GeneralFunctions.jl")
 
 export create_latex_project


### PR DESCRIPTION
# Fixed bug involving accessing latex templates

When creating a LaTeX project outside of the project directory, the relative path to the template used for LaTeX file creation would no longer work. This meant that the program would not fully create LaTeX projects. By removing the need to access this template, this issue was circumvented. 

## Changes 

- Removed reference to template file and instead all necessary text is added to the .tex file using conventional print statements 
- Changed title formatting to work with new system 
- Program now also formats in the current date in the form: [month] [year] 